### PR TITLE
collection: Ensure apt Performs An Update

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: vkhitrin
 name: libguestfs
-version: 1.1.3
+version: 1.1.4
 readme: README.md
 authors:
   - Vadim Khitrin <me@vkhitrin>

--- a/plugins/modules/guestfs_package.py
+++ b/plugins/modules/guestfs_package.py
@@ -129,7 +129,7 @@ import re
 PACKAGE_MANAGERS = {
     'dnf': {'present': 'dnf -y install', 'absent': 'dnf -y remove'},
     'yum': {'present': 'yum -y install', 'absent': 'yum -y remove'},
-    'apt': {'present': 'apt-get -y install', 'absent': 'apt-get -y remove'}
+    'apt': {'present': 'apt-get -q -y -o Dpkg::Options::=--force-confnew update; apt-get -y install', 'absent': 'apt-get -y remove'}
 }
 
 


### PR DESCRIPTION
When attempting to install a package on `apt` based images, we were
missing an `apt update` which improves the user experience.
Tools such as `virt-customize` perform an update before every
installation invocation.

Bump version to `1.1.4`.

Resolves #7.
