### PR TITLE
fix(modules): Align `python` Shebang

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ On Ansible Host:
 |       Distro       | Supported |                                                           Notes                                                            |
 | :----------------: | :-------- | :------------------------------------------------------------------------------------------------------------------------: |
 | Fedora/CentOS/RHEL | Yes       |                                                                                                                            |
-|       Ubuntu       | Yes       |                                                                                                                            |
-|       Debian       | Yes       |                                                                                                                            |
+|   Ubuntu/Debian    | Yes       |                                                                                                                            |
 |      Windows       | No        | [Not Supported, no plans to support right now](https://listman.redhat.com/archives/libguestfs/2016-February/msg00145.html) |
 
 ## Documentation

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: vkhitrin
 name: libguestfs
-version: 1.1.4
+version: 1.1.5
 readme: README.md
 authors:
   - Vadim Khitrin <me@vkhitrin>

--- a/plugins/module_utils/libguestfs.py
+++ b/plugins/module_utils/libguestfs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # Copyright: (c) 2018, Vadim Khitrin <me at vkhitrin.com>

--- a/plugins/modules/guestfs_command.py
+++ b/plugins/modules/guestfs_command.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # Copyright: (c) 2021, Vadim Khitrin <me at vkhitrin.com>

--- a/plugins/modules/guestfs_copy_in.py
+++ b/plugins/modules/guestfs_copy_in.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # Copyright: (c) 2021, Vadim Khitrin <me at vkhitrin.com>

--- a/plugins/modules/guestfs_copy_out.py
+++ b/plugins/modules/guestfs_copy_out.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # Copyright: (c) 202r, Vadim Khitrin <me at vkhitrin.com>

--- a/plugins/modules/guestfs_package.py
+++ b/plugins/modules/guestfs_package.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # Copyright: (c) 2021, Vadim Khitrin <me at vkhitrin.com>

--- a/plugins/modules/guestfs_user.py
+++ b/plugins/modules/guestfs_user.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # Copyright: (c) 2021, Vadim Khitrin <me at vkhitrin.com>


### PR DESCRIPTION
Correct the the `python` shebang to allow Ansible python interpreter
discovery to work [1]

Bump version to `1.1.5`.

Closes #9.

[1] https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#python-shebang-utf-8-coding
